### PR TITLE
Revert to default action :create so the file can be updated

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,5 +18,4 @@ template "#{node['rbenv']['root_path']}/vars" do
   owner "root"
   group "root"
   mode 0644
-  action :create_if_missing
 end


### PR DESCRIPTION
We updated to Ruby 2.1 and modified some GC tuning but the cooking of the servers is not updating the tuning variables.

This switches the action to the default `:create` so that it will be updated if any changes are detected.