### PR TITLE
Update rbenv cookbook name to ruby_rbenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Description
 
 Installs the [rbenv-vars](https://github.com/sstephenson/rbenv-vars)
-plugin for the rbenv::system install.
+plugin for the ruby_rbenv::system install.
 
 ## Usage
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 #!/usr/bin/env rake
 
-@cookbook = "rbenv"
+@cookbook = "ruby_rbenv"
 
 desc "Runs foodcritc linter"
 task :foodcritic do

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,4 +2,4 @@ name 'rbenv_vars'
 description 'Install rbenv-vars plugin'
 version '0.1.1'
 
-depends 'rbenv'
+depends 'ruby_rbenv'


### PR DESCRIPTION
The `rbenv` cookbook was renamed to `ruby_rbenv`.
